### PR TITLE
Alafr arch structure part2

### DIFF
--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -904,7 +904,7 @@ class _Structure(ArchComponent.Component):
                 inverse_placement = placement.inverse()
             if extrusion:
                 if len(extrusion.Edges) == 1 and DraftGeomUtils.geomType(extrusion.Edges[0]) == "Line":
-                    extrusion = DraftGeomUtils.vec(extrusion.Edges[0])
+                    extrusion = DraftGeomUtils.vec(extrusion.Edges[0], True)
                 if isinstance(extrusion, FreeCAD.Vector):
                     extrusion = inverse_placement.Rotation.multVec(extrusion)
             elif normal:

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -250,7 +250,8 @@ class _CommandStructuralSystem:
                 FreeCADGui.doCommand("Draft.autogroup(obj)")
                 FreeCAD.ActiveDocument.commitTransaction()
                 FreeCAD.ActiveDocument.recompute()
-                return
+            else:
+                FreeCAD.Console.PrintError(translate("Arch", "Please select at least an axis object") + "\n")
 
 
 class _CommandStructure:

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -217,7 +217,7 @@ class _CommandStructuresFromSelection:
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()
         else:
-            FreeCAD.Console.PrintError(translate("Arch", "Please select the base object first and then the edges to use as extrusion paths"))
+            FreeCAD.Console.PrintError(translate("Arch", "Please select the base object first and then the edges to use as extrusion paths") + "\n")
 
 
 class _CommandStructuralSystem:

--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -57,7 +57,7 @@ class ArchWorkbench(FreeCADGui.Workbench):
         import Arch
 
         # Set up command lists
-        self.archtools = ["Arch_Wall", "Arch_Structure", "Arch_Rebar",
+        self.archtools = ["Arch_Wall", "Arch_StructureTools", "Arch_Rebar",
                           "Arch_BuildingPart",
                           "Arch_Project", "Arch_Site", "Arch_Building",
                           "Arch_Floor", "Arch_Reference",

--- a/src/Mod/Arch/Resources/Arch.qrc
+++ b/src/Mod/Arch/Resources/Arch.qrc
@@ -35,6 +35,7 @@
         <file>icons/Arch_Material_Multi.svg</file>
         <file>icons/Arch_MergeWalls.svg</file>
         <file>icons/Arch_MeshToShape.svg</file>
+        <file>icons/Arch_MultipleStructures.svg</file>
         <file>icons/Arch_Nest.svg</file>
         <file>icons/Arch_Panel.svg</file>
         <file>icons/Arch_Panel_Clone.svg</file>

--- a/src/Mod/Arch/Resources/icons/Arch_MultipleStructures.svg
+++ b/src/Mod/Arch/Resources/icons/Arch_MultipleStructures.svg
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="Arch_MultipleStructures.svg">
+  <defs
+     id="defs2987">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4859"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#729fcf;stroke-width:1pt;stroke-opacity:1;fill:#729fcf;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-56.67589 : 60.541728 : 1"
+       inkscape:vp_y="0 : 1102.1522 : 0"
+       inkscape:vp_z="125.67018 : 63.747989 : 1"
+       inkscape:persp3d-origin="37.520737 : 35.960393 : 1"
+       id="perspective2993" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-56.67589 : 60.541728 : 1"
+       inkscape:vp_y="0 : 1102.1522 : 0"
+       inkscape:vp_z="125.67018 : 63.747989 : 1"
+       inkscape:persp3d-origin="37.520737 : 35.960393 : 1"
+       id="perspective2993-4" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-46.892514 : 61.217294 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="95.652941 : 64.126385 : 1"
+       inkscape:persp3d-origin="26.74385 : 38.914263 : 1"
+       id="perspective2993-7" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-49.818182 : 58.545455 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="92.727273 : 61.454546 : 1"
+       inkscape:persp3d-origin="23.818182 : 36.242424 : 1"
+       id="perspective2993-3" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-56.67589 : 60.541728 : 1"
+       inkscape:vp_y="0 : 1102.1522 : 0"
+       inkscape:vp_z="125.67018 : 63.747989 : 1"
+       inkscape:persp3d-origin="37.520737 : 35.960393 : 1"
+       id="perspective2993-9" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3850-6">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1;"
+         offset="0"
+         id="stop3852-2" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:1"
+         offset="1"
+         id="stop3854-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3858-2">
+      <stop
+         style="stop-color:#ffc900;stop-opacity:1;"
+         offset="0"
+         id="stop3860-7" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3862-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3850-6"
+       id="linearGradient3972"
+       gradientUnits="userSpaceOnUse"
+       x1="69.848015"
+       y1="54.851124"
+       x2="66.151985"
+       y2="27.481174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3858-2"
+       id="linearGradient3974"
+       gradientUnits="userSpaceOnUse"
+       x1="59.417618"
+       y1="56.224525"
+       x2="55.563385"
+       y2="26.598274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3850-6"
+       id="linearGradient3986"
+       gradientUnits="userSpaceOnUse"
+       x1="69"
+       y1="53"
+       x2="66.006668"
+       y2="21.705095"
+       gradientTransform="matrix(-1,0,0,1,111.00667,0.294905)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3858-2"
+       id="linearGradient3988"
+       gradientUnits="userSpaceOnUse"
+       x1="57"
+       y1="54"
+       x2="55.006672"
+       y2="20.705095"
+       gradientTransform="matrix(-1,0,0,1,111.00667,0.294905)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3850-6-1"
+       id="linearGradient3986-6"
+       gradientUnits="userSpaceOnUse"
+       x1="69.018059"
+       y1="51.449608"
+       x2="66.151985"
+       y2="27.481174" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3850-6-1">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1;"
+         offset="0"
+         id="stop3852-2-8" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:1"
+         offset="1"
+         id="stop3854-9-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3858-2-2"
+       id="linearGradient3988-9"
+       gradientUnits="userSpaceOnUse"
+       x1="57.018063"
+       y1="52.449608"
+       x2="55.563385"
+       y2="26.598274" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3858-2-2">
+      <stop
+         style="stop-color:#ffc900;stop-opacity:1;"
+         offset="0"
+         id="stop3860-7-0" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3862-0-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3850-6"
+       id="linearGradient4819"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,111.00667,0.294905)"
+       x1="69"
+       y1="53"
+       x2="66.006668"
+       y2="21.705095" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3858-2"
+       id="linearGradient4821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,111.00667,0.294905)"
+       x1="57"
+       y1="54"
+       x2="55.006672"
+       y2="20.705095" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3850-6-1"
+       id="linearGradient5160"
+       gradientUnits="userSpaceOnUse"
+       x1="69.018059"
+       y1="51.449608"
+       x2="66.151985"
+       y2="27.481174" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.679636"
+     inkscape:cx="28.232901"
+     inkscape:cy="42.775659"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3006"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>alafr</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Arch_Structure</dc:title>
+        <dc:date>2020-04-08</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Arch/Resources/icons/Arch_MultipleStructures.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g4817"
+       transform="translate(0.9933,1.705095)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         d="m 50,24 0.0067,35.294905 -12,-4 L 38,24 C 38,19 36.0067,13.294905 33.0067,10.294905 l 8,-7 C 47.0067,8.294905 50,16 50,24 Z"
+         style="color:#000000;visibility:visible;fill:url(#linearGradient4819);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+         id="path3927-5-6"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         d="M 60,20 C 60.016086,13.092104 56.0067,4.294905 50.0067,1.294905 l -9,2 C 46.0067,7.294905 50,16 50,24 l 0.0067,35.294905 10,-4 z"
+         style="color:#000000;visibility:visible;fill:url(#linearGradient4821);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:fill markers stroke"
+         id="path3929-3-0"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 58.0067,21.294905 v 32.539551 l -3.552149,1.456647 -2.447881,1.003802 3e-5,-33 z"
+         id="path3846-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 48,24 -8,-2 -10e-7,32 7.989329,2.520349 z"
+         id="path3848-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       id="g3978-3"
+       transform="matrix(-1,0,0,1,61.006671,-1.705095)">
+      <g
+         id="g3866-9-7"
+         transform="translate(-22,2)">
+        <g
+           id="g5158"
+           transform="translate(2.006671,-0.294905)">
+          <path
+             sodipodi:nodetypes="ccccc"
+             d="M 52,23 61,25 71.006671,23 63,21 Z"
+             style="color:#000000;visibility:visible;fill:#fce94f;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path3925-7-3-5"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             d="M 61,25 V 57 L 71.006671,53 V 23 Z"
+             style="color:#000000;visibility:visible;fill:url(#linearGradient5160);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path3927-5-6-9"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             d="m 52,23 9,2 v 32 l -9,-4 z"
+             style="color:#000000;visibility:visible;fill:url(#linearGradient3988-9);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+             id="path3929-3-0-2"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 54,26 V 51.539551 L 59,54 V 27 Z"
+             id="path3846-6-2"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 63,27 6.006671,-1.550391 v 26.255486 l -5.989329,2.520349 z"
+             id="path3848-2-8"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g5168">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3878-4"
+         d="M 5,52 V 23"
+         style="fill:#00ffff;stroke:#0b1521;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3878"
+         d="M 5,52 V 22"
+         style="fill:#00ffff;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g5172">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path3878-2-8"
+         d="M 34,56 V 25 c 0,-3 -1,-7 -4,-10"
+         style="fill:none;stroke:#0b1521;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path3878-2"
+         d="M 34,56 V 25 c 0,-3 -1,-7 -4,-10"
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Arch/Resources/icons/Arch_MultipleStructures.svg
+++ b/src/Mod/Arch/Resources/icons/Arch_MultipleStructures.svg
@@ -208,9 +208,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="6.679636"
-     inkscape:cx="28.232901"
-     inkscape:cy="42.775659"
+     inkscape:zoom="4"
+     inkscape:cx="39.716144"
+     inkscape:cy="28.397638"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
@@ -239,7 +239,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>alafr</dc:title>
@@ -262,7 +262,7 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title></dc:title>
+            <dc:title />
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
@@ -274,35 +274,35 @@
      inkscape:groupmode="layer">
     <g
        id="g4817"
-       transform="translate(0.9933,1.705095)">
+       transform="translate(2.010672,1.479651)">
       <path
          sodipodi:nodetypes="ccccccc"
-         d="m 50,24 0.0067,35.294905 -12,-4 L 38,24 C 38,19 36.0067,13.294905 33.0067,10.294905 l 8,-7 C 47.0067,8.294905 50,16 50,24 Z"
+         d="m 50,24 0.0067,35.294905 -10,-4 V 24 c 0,-5 -4.017372,-11.479651 -7.017372,-14.479651 L 40.0067,2.294905 C 46.0067,7.294905 50,16 50,24 Z"
          style="color:#000000;visibility:visible;fill:url(#linearGradient4819);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
          id="path3927-5-6"
          inkscape:connector-curvature="0" />
       <path
          sodipodi:nodetypes="ccccccc"
-         d="M 60,20 C 60.016086,13.092104 56.0067,4.294905 50.0067,1.294905 l -9,2 C 46.0067,7.294905 50,16 50,24 l 0.0067,35.294905 10,-4 z"
+         d="m 59.0067,20.520349 c -0.01737,-5.479651 -4.017372,-16 -10.017372,-19 L 40.0067,2.294905 C 45.0067,6.294905 50,16 50,24 l 0.0067,35.294905 9,-4 z"
          style="color:#000000;visibility:visible;fill:url(#linearGradient4821);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:fill markers stroke"
          id="path3929-3-0"
          inkscape:connector-curvature="0" />
       <path
          style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 58.0067,21.294905 v 32.539551 l -3.552149,1.456647 -2.447881,1.003802 3e-5,-33 z"
+         d="m 57.0067,21.294905 v 32.539551 l -5.00003,2.460449 3e-5,-33 z"
          id="path3846-6"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
+         sodipodi:nodetypes="ccccc" />
       <path
          style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 48,24 -8,-2 -10e-7,32 7.989329,2.520349 z"
+         d="m 48,24 -5.9933,-2 v 32 l 5.982628,2.520349 z"
          id="path3848-2"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc" />
     </g>
     <g
        id="g3978-3"
-       transform="matrix(-1,0,0,1,61.006671,-1.705095)">
+       transform="matrix(-1,0,0,1,61.006671,2.294905)">
       <g
          id="g3866-9-7"
          transform="translate(-22,2)">
@@ -311,13 +311,13 @@
            transform="translate(2.006671,-0.294905)">
           <path
              sodipodi:nodetypes="ccccc"
-             d="M 52,23 61,25 71.006671,23 63,21 Z"
+             d="m 52,23 9,2 9,-2 -8,-2 z"
              style="color:#000000;visibility:visible;fill:#fce94f;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
              id="path3925-7-3-5"
              inkscape:connector-curvature="0" />
           <path
              sodipodi:nodetypes="ccccc"
-             d="M 61,25 V 57 L 71.006671,53 V 23 Z"
+             d="m 61,25 v 32 l 9,-4 V 23 Z"
              style="color:#000000;visibility:visible;fill:url(#linearGradient5160);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
              id="path3927-5-6-9"
              inkscape:connector-curvature="0" />
@@ -335,7 +335,7 @@
              sodipodi:nodetypes="ccccc" />
           <path
              style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 63,27 6.006671,-1.550391 v 26.255486 l -5.989329,2.520349 z"
+             d="m 63,27 5,-1.550391 v 26.255486 l -4.982658,2.520349 z"
              id="path3848-2-8"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccc" />
@@ -343,7 +343,8 @@
       </g>
     </g>
     <g
-       id="g5168">
+       id="g5168"
+       transform="translate(0,4)">
       <path
          inkscape:connector-curvature="0"
          id="path3878-4"
@@ -358,18 +359,19 @@
          sodipodi:nodetypes="cc" />
     </g>
     <g
-       id="g5172">
+       id="g5172"
+       transform="translate(2)">
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path3878-2-8"
-         d="M 34,56 V 25 c 0,-3 -1,-7 -4,-10"
+         d="M 34,56 V 25 c 0,-3 -5,-9 -8,-12"
          style="fill:none;stroke:#0b1521;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccc"
          inkscape:connector-curvature="0"
          id="path3878-2"
-         d="M 34,56 V 25 c 0,-3 -1,-7 -4,-10"
+         d="M 34,56 V 25 c 0,-3 -5,-9 -8,-12"
          style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
   </g>

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -2412,37 +2412,26 @@ def removeSplitter(shape):
     return None
 
 
-def get_shape_with_real_placement(obj):
-    """ Returns the object's shape with it's real Placement (object's placement is multiplied
-        with the linked object's placement if LinkTransform is True). """
-    shape = None
-    if hasattr(obj, "Shape") and obj.Shape:
-        shape = obj.Shape.copy()
-        if hasattr(obj, "LinkTransform") and obj.LinkTransform:
-            shape.Placement = shape.Placement.multiply(obj.LinkedObject.Placement)
-    return shape
-
-
 def get_referenced_edges(property_value):
-    """ Returns the Edges referenced by the value of a App:PropertyLink or App::PropertyLinkSub property. """
-    shape = get_shape_with_real_placement(property_value)
-    if shape:
-        edges = shape.Edges
-    else:
-        if not isinstance(property_value, list):
-            property_value = [property_value]
-        edges = []
-        for object, subelement_names in property_value:
-            object_shape = get_shape_with_real_placement(object)
-            if object_shape:
+    """ Returns the Edges referenced by the value of a App:PropertyLink, App::PropertyLinkList,
+        App::PropertyLinkSub or App::PropertyLinkSubList property. """
+    edges = []
+    if not isinstance(property_value, list):
+        property_value = [property_value]
+    for element in property_value:
+        if hasattr(element, "Shape") and element.Shape:
+            edges += shape.Edges
+        elif isinstance(element, tuple) and len(element) == 2:
+            object, subelement_names = element
+            if hasattr(object, "Shape") and object.Shape:
                 if len(subelement_names) == 1 and subelement_names[0] == "":
-                    edges += object_shape.Edges
+                    edges += object.Shape.Edges
                 else:
                     for subelement_name in subelement_names:
                         if subelement_name.startswith("Edge"):
                             edge_number = int(subelement_name.lstrip("Edge")) - 1
-                            if edge_number < len(object_shape.Edges):
-                                edges.append(object_shape.Edges[edge_number])
+                            if edge_number < len(object.Shape.Edges):
+                                edges.append(object.Shape.Edges[edge_number])
     return edges
 
 

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -57,11 +57,15 @@ def precision():
     precisionInt = (precisionInt if precisionInt <=10 else precisionMax)
     return precisionInt								#return params.GetInt("precision",6)
 
-def vec(edge):
-    "vec(edge) or vec(line): returns a vector from an edge or a Part.LineSegment"
-    # if edge is not straight, you'll get strange results!
-    if isinstance(edge,Part.Shape):
-        return edge.Vertexes[-1].Point.sub(edge.Vertexes[0].Point)
+def vec(edge, use_orientation = False):
+    """ vec(edge[, use_orientation]) or vec(line): returns a vector from an edge or a Part.LineSegment.
+        If use_orientation is True, it takes into account the edges orientation.
+        If edge is not straight, you'll get strange results! """
+    if isinstance(edge, Part.Edge):
+        if edge.Orientation == "Forward" or not use_orientation:
+            return edge.Vertexes[-1].Point.sub(edge.Vertexes[0].Point)
+        else:
+            return edge.Vertexes[0].Point.sub(edge.Vertexes[-1].Point)
     elif isinstance(edge,Part.LineSegment):
         return edge.EndPoint.sub(edge.StartPoint)
     else:


### PR DESCRIPTION
(More details in the individual commits)
* Add a command that creates multiple Arch Structure objects from a selected base, using each selected edge as an extrusion path. It creates one Arch Structure object from each edge. Therefore, the Arch Structure objects can then be individually edited if needed.
* Split the command Arch Structural System from Arch Structure. For backwards compatibility, the command Arch Structure will run the command Arch Structural System when the requirements for the Arch Structural System (Structure + Axis) are met.
* Add the options: StartOffset, EndOffset: this trims (negative values) or extends (positive values) the extrusion path.
* Move code dealing with geometry in DraftGeomUtils: functions get_extended_wire, get_placement_perpendicular_to_wire, get_referenced_edges
* In DraftGeomUtils.vec() add the option use_orientation